### PR TITLE
Adding support for transformers>=4.40.2 to avoid crash with mbpp [MLI-2348]

### DIFF
--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -305,9 +305,12 @@ def complete_code(
                             num_return_sequences=batch_size,
                             **gen_kwargs,
                         )
-                    except ValueError:
+                    except ValueError as e:
                         # When the length of input_ids == max_length, the generation is the same as the input
-                        generated_tokens = inputs
+                        if str(e).startswith(f"Input length of input_ids is {inputs.shape[1]}, but `max_length` is set to {gen_kwargs['max_length']}"):
+                            generated_tokens = inputs
+                        else:
+                            raise e
 
             # each task is generated batch_size times
             generated_tasks = batch["task_id"].repeat(batch_size)

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -308,6 +308,7 @@ def complete_code(
                     except ValueError as e:
                         # When the length of input_ids == max_length, the generation is the same as the input
                         if str(e).startswith(f"Input length of input_ids is {inputs.shape[1]}, but `max_length` is set to {gen_kwargs['max_length']}"):
+                            warnings.warn(f"An error with the following message was thrown: {e}. Returning the input as the generation.")
                             generated_tokens = inputs
                         else:
                             raise e


### PR DESCRIPTION
__Description__

- Since transformers 4.38, the library will raise an exception if max_length is set to a value that doesn't include the input size. This means that bigcode will fail when running mbpp. 
- However, we need to be able to set max length to replicate mbpp results effectively.
- Added support to handle this exception if the length of input_ids equals the max_length. 

__Testing__

- Upgrading transformers package to version 4.40.2 and testing the following command succeeds. 

```
accelerate launch main.py \
  --model ~/models/hf-code-llama-7b-instruct \
  --tasks mbpp \
  --max_length_generation 512 \
  --allow_code_execution \
  --precision bf16 \
  --do_sample False
```

- Verify that the results of evaluation are the same as running mbpp before the package upgrade. Both provide results 
```
"mbpp": {
    "pass@1": 0.388
}
```

- Further, the below two files show the generations resulting from the above command before and after the package upgrade. Asserted that the generations were equivalent for each task_id. 
[validate_transformers_new.json](https://github.com/user-attachments/files/15780641/validate_transformers_new.json)
[validate_transformers_old.json](https://github.com/user-attachments/files/15780642/validate_transformers_old.json)
